### PR TITLE
Adopt functional options pattern for exporter setup

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -148,7 +148,7 @@ func WithServiceName(n string) ExporterOption {
 	}
 }
 
-// WithSkipSSL sets the ServiceName.
+// WithSkipSSL sets the InsecureSkipVerify flag on the HTTP transport.
 func WithSkipSSL(skip bool) ExporterOption {
 	return func(o *Options) {
 		o.SkipSSLVerification = skip

--- a/exporter.go
+++ b/exporter.go
@@ -19,8 +19,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/rcrowley/go-metrics"
 	"crypto/tls"
+
+	"github.com/rcrowley/go-metrics"
 )
 
 const defaultCfMetricsServiceName = "cf-metrics"
@@ -41,6 +42,7 @@ type timeHelper interface {
 	currentTimeInMillis() int64
 }
 
+// Options is used when starting an exporter.
 type Options struct {
 	Frequency           time.Duration
 	InstanceId          string
@@ -53,60 +55,130 @@ type Options struct {
 	SkipSSLVerification bool
 }
 
-func StartExporter(registry metrics.Registry) {
-	StartExporterWithOptions(registry, &Options{})
-}
-
-func StartExporterWithOptions(registry metrics.Registry, options *Options) {
-	if options.ServiceName == "" {
-		options.ServiceName = defaultCfMetricsServiceName
-	}
-
-	if options.Token == "" {
-		apiToken, err := getToken(options.ServiceName)
+func (o *Options) fillDefaults() {
+	if o.Token == "" {
+		apiToken, err := getToken(o.ServiceName)
 		if err != nil {
 			log.Printf("Could not get apiToken: %s", err.Error())
 			return
 		}
 
-		options.Token = apiToken
+		o.Token = apiToken
 	}
 
-	if options.Url == "" {
-		apiUrl, err := getUrl(options.ServiceName)
+	if o.Url == "" {
+		apiUrl, err := getUrl(o.ServiceName)
 		if err != nil {
 			log.Printf("Could not get Url: %s", err.Error())
 			return
 		}
 
-		options.Url = apiUrl
+		o.Url = apiUrl
 	}
 
-	if options.AppGuid == "" {
+	if o.AppGuid == "" {
 		appGuid, err := getAppGuid()
 		if err != nil {
 			log.Printf("Could not get app guid: %s", err.Error())
 			return
 		}
 
-		options.AppGuid = appGuid
+		o.AppGuid = appGuid
+	}
+}
+
+// ExporterOption is used to configure an exporter.
+type ExporterOption func(*Options)
+
+// WithFrequency sets the frequency. The default is a minute.
+func WithFrequency(f time.Duration) ExporterOption {
+	return func(o *Options) {
+		o.Frequency = f
+	}
+}
+
+// WithInstanceId sets the instance ID. The default is read from the
+// environment variable INSTANCE_GUID
+func WithInstanceId(guid string) ExporterOption {
+	return func(o *Options) {
+		o.InstanceId = guid
+	}
+}
+
+// WithInstanceIndex sets the instance index. The default is read from the
+// environment variable INSTANCE_INDEX.
+func WithInstanceIndex(id string) ExporterOption {
+	return func(o *Options) {
+		o.InstanceId = id
+	}
+}
+
+// WithToken sets the token.
+func WithToken(token string) ExporterOption {
+	return func(o *Options) {
+		o.Token = token
+	}
+}
+
+// WithURL sets the URL.
+func WithURL(URL string) ExporterOption {
+	return func(o *Options) {
+		o.Url = URL
+	}
+}
+
+// WithAppGuid sets the AppGuid.
+func WithAppGuid(guid string) ExporterOption {
+	return func(o *Options) {
+		o.AppGuid = guid
+	}
+}
+
+// WithTimeUnit sets the TimeUnit.
+func WithTimeUnit(u time.Duration) ExporterOption {
+	return func(o *Options) {
+		o.TimeUnit = u
+	}
+}
+
+// WithServiceName sets the ServiceName.
+func WithServiceName(n string) ExporterOption {
+	return func(o *Options) {
+		o.ServiceName = n
+	}
+}
+
+// WithSkipSSL sets the ServiceName.
+func WithSkipSSL(skip bool) ExporterOption {
+	return func(o *Options) {
+		o.SkipSSLVerification = skip
+	}
+}
+
+// StartExporter starts a new exporter on the current go-routine and will
+// never exit.
+func StartExporter(registry metrics.Registry, opts ...ExporterOption) {
+	options := &Options{
+		Frequency:     time.Minute,
+		InstanceIndex: getInstanceIndex(),
+		InstanceId:    getInstanceGuid(),
+		ServiceName:   defaultCfMetricsServiceName,
+		TimeUnit:      time.Millisecond,
 	}
 
-	if options.InstanceIndex == "" {
-		options.InstanceIndex = getInstanceIndex()
+	for _, o := range opts {
+		o(options)
 	}
 
-	if options.InstanceId == "" {
-		options.InstanceId = getInstanceGuid()
-	}
+	options.fillDefaults()
 
-	if int64(options.TimeUnit) == 0 {
-		options.TimeUnit = time.Millisecond
-	}
+	StartExporterWithOptions(registry, options)
+}
 
-	if int64(options.Frequency) == 0 {
-		options.Frequency = time.Minute
-	}
+// StartExporterWithOptions starts a new exporter with provided options on
+// the current go-routine and will never exit.
+func StartExporterWithOptions(registry metrics.Registry, options *Options) {
+	options.fillDefaults()
 
 	httpTransport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: options.SkipSSLVerification},


### PR DESCRIPTION
This pattern is described well by Dave Cheney's [Functional options for friendly APIs](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) post and is used in [grpc](https://github.com/grpc/grpc-go).